### PR TITLE
fix: 两个开箱即崩的 bug, 麻烦 vibe 完跑一遍

### DIFF
--- a/build_dist.py
+++ b/build_dist.py
@@ -4,6 +4,13 @@ import os, sys, shutil, subprocess, platform
 
 ROOT = os.path.dirname(os.path.abspath(__file__))
 DIST = os.path.join(ROOT, 'dist', 'WeChatExport')
+
+NODE_EXE = os.environ.get('NODE_EXE', r'D:\Program Files\nodejs\node.exe')
+WEFLOW_DIR = os.environ.get('WEFLOW_DIR', r'C:\Users\OK\AppData\Local\Programs\WeFlow')
+WCDB_DLL_DIR = os.environ.get('WCDB_DLL_DIR', os.path.join(WEFLOW_DIR, 'resources', 'resources', 'wcdb', 'win32', 'x64'))
+KEY_DLL_DIR = os.environ.get('KEY_DLL_DIR', os.path.join(WEFLOW_DIR, 'resources', 'resources', 'key', 'win32', 'x64'))
+VC_RUNTIME_DIR = os.environ.get('VC_RUNTIME_DIR', WEFLOW_DIR)
+
 print('='*50)
 print('构建全量发布包')
 print('='*50)
@@ -31,9 +38,8 @@ os.makedirs(os.path.join(DIST, 'dll'), exist_ok=True)
 os.makedirs(os.path.join(DIST, 'runtime'), exist_ok=True)
 
 # Node.js 运行时
-NODE_SRC = r'D:\Program Files\nodejs\node.exe'
-if os.path.exists(NODE_SRC):
-    shutil.copy(NODE_SRC, os.path.join(DIST, 'runtime', 'node.exe'))
+if os.path.exists(NODE_EXE):
+    shutil.copy(NODE_EXE, os.path.join(DIST, 'runtime', 'node.exe'))
     print('  [OK] node.exe')
 
 # Node.js 依赖
@@ -59,24 +65,22 @@ if os.path.exists(KOFI_NATIVE):
     print('  [OK] @koromix/koffi-win32-x64')
 
 # WCDB DLLs
-WCDB_SRC = r'C:\Users\OK\AppData\Local\Programs\WeFlow\resources\resources\wcdb\win32\x64'
 for f in ['WCDB.dll', 'wcdb_api.dll', 'SDL2.dll']:
-    src = os.path.join(WCDB_SRC, f)
+    src = os.path.join(WCDB_DLL_DIR, f)
     if os.path.exists(src):
         shutil.copy(src, os.path.join(DIST, 'dll'))
         print(f'  [OK] {f}')
 
 # wx_key.dll
-KEY_SRC = r'C:\Users\OK\AppData\Local\Programs\WeFlow\resources\resources\key\win32\x64'
-for f in os.listdir(KEY_SRC):
-    if f.endswith('.dll'):
-        shutil.copy(os.path.join(KEY_SRC, f), os.path.join(DIST, 'dll'))
-        print(f'  [OK] {f}')
+if os.path.exists(KEY_DLL_DIR):
+    for f in os.listdir(KEY_DLL_DIR):
+        if f.endswith('.dll'):
+            shutil.copy(os.path.join(KEY_DLL_DIR, f), os.path.join(DIST, 'dll'))
+            print(f'  [OK] {f}')
 
 # VC++ 运行时 DLLs
-RUNTIME_SRC = r'C:\Users\OK\AppData\Local\Programs\WeFlow'
 for f in ['msvcp140.dll', 'msvcp140_1.dll', 'vcruntime140.dll', 'vcruntime140_1.dll']:
-    src = os.path.join(RUNTIME_SRC, f)
+    src = os.path.join(VC_RUNTIME_DIR, f)
     if os.path.exists(src):
         shutil.copy(src, os.path.join(DIST, 'runtime'))
         print(f'  [OK] {f}')

--- a/db_exporter/main.py
+++ b/db_exporter/main.py
@@ -16,8 +16,8 @@ from collections import defaultdict
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-DB_PATH = r"D:\储存信息\xwechat_files\wxid_caccoealsdbj12_e8c8\db_storage\message\message_0.db"
-CONFIG_DIR = r"D:\储存信息\xwechat_files\wxid_caccoealsdbj12_e8c8\config"
+DB_PATH = os.environ.get('WX_DB_PATH', r"D:\储存信息\xwechat_files\wxid_caccoealsdbj12_e8c8\db_storage\message\message_0.db")
+CONFIG_DIR = os.environ.get('WX_CONFIG_DIR', r"D:\储存信息\xwechat_files\wxid_caccoealsdbj12_e8c8\config")
 
 def scan_config():
     """扫描配置文件，寻找密钥材料"""

--- a/run_gui.py
+++ b/run_gui.py
@@ -2,7 +2,7 @@
 """微信聊天记录恢复工具 v1.0 — GUI 启动入口"""
 import os, sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from gui.app import ChatApp
+from gui.app_v3 import App as ChatApp
 
 if __name__ == '__main__':
     app = ChatApp()


### PR DESCRIPTION
自述文件曰:

> ### 源码运行
>  ```
> pip install -r requirements.txt
> python run_gui.py
> ```

 就ok了对吗, `OK` 先生?  能肯定这是未经审查的 **AI Slop**.

```py
"""微信聊天记录恢复工具 v1.0 — GUI 启动入口"""
import os, sys
sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
from gui.app import ChatApp

if __name__ == '__main__':
    app = ChatApp()
```

`gui.app` 去哪了? 现已为您修复包导入的 *"typo"* 问题, 这应该不是您只让您的 Agent 修改了主程序导致的吧?


```py
# wx_key.dll
KEY_SRC = r'C:\Users\OK\AppData\Local\Programs\WeFlow\resources\resources\key\win32\x64'
```

```py
# WCDB DLLs
WCDB_SRC = r'C:\Users\OK\AppData\Local\Programs\WeFlow\resources\resources\wcdb\win32\x64'
```

等几处硬编码已为您作修改, 现在可以使用环境变量在运行前进行配置并在未配置时自动回退到OK先生, 而无需我们转生成为 OK 先生就得以构建本项目

其余几处不知所云的调用也请您后续与您的 Agent 进行修改与讨论，谢谢!

*未卜先知*
```py
    # 已知的 wxid
    wxid = 'wxid_caccoealsdbj12'
```

*神级预判*
```py
    """扫描常见位置找 xwechat_files 目录"""
    candidates = [
        os.path.join(os.environ.get('USERPROFILE', 'C:'), 'Documents', 'xwechat_files'),
        'D:\\wxxinxi\\xwechat_files',
        'D:\\储存信息\\xwechat_files',
    ]
```

## 写在最后
工具只是你的衍生, 不要高看工具, 更不要高看你自己

> 对本 PR 有任何疑问，可以就此与您的 Agent 进行讨论.